### PR TITLE
attempt to fix upload error in Azure due to unicode file name

### DIFF
--- a/storages/backends/azure_storage.py
+++ b/storages/backends/azure_storage.py
@@ -117,7 +117,7 @@ class AzureStorage(Storage):
                 sas_token = None
             return self.connection.make_blob_url(
                 container_name=self.azure_container,
-                blob_name=name,
+                blob_name=name.encode('ascii', 'ignore'),
                 protocol=self.azure_protocol,
                 sas_token=sas_token
             )


### PR DESCRIPTION
Experimental, i have no way to test it right now. This "fix" would lead to the loss of special characters from the filename(filename would become empty if contained only special characters).